### PR TITLE
fix: tooltipBorderRadius not used

### DIFF
--- a/lib/src/tutorial_overlay.dart
+++ b/lib/src/tutorial_overlay.dart
@@ -350,10 +350,7 @@ Other possible causes:
             padding: tooltipPadding ?? EdgeInsets.all(20),
             decoration: BoxDecoration(
               color: tooltipBackgroundColor,
-              borderRadius: BorderRadius.circular(12),
-              boxShadow: const [
-                // BoxShadow(blurRadius: 8, color: Colors.black26)
-              ],
+              borderRadius: BorderRadius.circular(tooltipBorderRadius),
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
There was an argument `tooltipBorderRadius` which was never used