### PR TITLE
feat: add dismissing of overlay from code

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ TutorialStep(
 )
 ```
 
+To dismiss the tutorial overlay from code you can simply call:
+
+```dart
+final tutorial = TutorialOverlay(
+  context: context,
+  steps: steps,
+);
+
+tutorial.show();
+
+// Then just call where you need it
+tutorial.dismiss()
+```
+
 ## Migration from v1.0.0
 
 If you're upgrading from v1.0.0, replace the global onNext callback with step-specific ones:

--- a/lib/src/tutorial_overlay.dart
+++ b/lib/src/tutorial_overlay.dart
@@ -176,6 +176,9 @@ class TutorialOverlay {
   /// Starts the tutorial by showing the first step.
   void show() => _showStep();
 
+  /// Dismisses the tutorial overlay.
+  void dismiss() => _removeOverlay();
+
   // ... rest of your existing implementation remains the same
 
   void _showStep() {


### PR DESCRIPTION
In my use case I needed to be able to dismiss the overlay/tooltip from code to for example close it when the user uses the phones back button and pops the current page/widget the overlay was for.