### PR TITLE
feat: add titleStyle/descriptionStyle support and fix tooltip sizing and overlay tint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ### Added
 
 - `dismiss()` method to `TutorialOverlay` for programmatic control of the overlay visibility.
+- `titleStyle` and `descriptionStyle` to `TutorialOverlay` for custom title and descriptions styling.
 
 ### Fixed
 
 - `tooltipBorderRadius` property is now correctly applied to the tooltip container.
-- Typo in `TutorialOverlay` error message and assertions.
+- `tooltipMaxWidth` property now correctly sizes tooltips that span across the whole width of the screen.
+- `overlayTint` property is now correctly applied to the BackdropFilter. 
+- Typo in `TutorialOverlay` error message, assertions and finishText.
 - General spelling and documentation improvements across the package.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,25 @@
+## [1.0.6] - 2026-06-09
+
+### Added
+
+- `titleStyle` and `descriptionStyle` to `TutorialOverlay` for custom title and descriptions styling.
+
+### Fixed
+
+- `tooltipMaxWidth` property now correctly sizes tooltips that span across the whole width of the screen.
+- `overlayTint` property is now correctly applied to the BackdropFilter. 
+- Typo in `TutorialOverlay` finishText property name.
+
 ## [1.0.5] - 2026-05-30
 
 ### Added
 
 - `dismiss()` method to `TutorialOverlay` for programmatic control of the overlay visibility.
-- `titleStyle` and `descriptionStyle` to `TutorialOverlay` for custom title and descriptions styling.
 
 ### Fixed
 
 - `tooltipBorderRadius` property is now correctly applied to the tooltip container.
-- `tooltipMaxWidth` property now correctly sizes tooltips that span across the whole width of the screen.
-- `overlayTint` property is now correctly applied to the BackdropFilter. 
-- Typo in `TutorialOverlay` error message, assertions and finishText.
+- Typo in `TutorialOverlay` error message and assertions.
 - General spelling and documentation improvements across the package.
 
 

--- a/lib/src/tutorial_overlay.dart
+++ b/lib/src/tutorial_overlay.dart
@@ -113,13 +113,19 @@ class TutorialOverlay {
   EdgeInsetsGeometry? tooltipPadding;
 
   /// Custom text for the "Finish" button.
-  final String? finshText;
+  final String? finishText;
 
   /// Custom text for the "Next" button.
   final String? nextText;
 
   /// Custom text for the "Skip" button.
   final String? skipText;
+
+  // Custom style for the title text.
+  final TextStyle? titleStyle;
+
+  // Custom style for the description text.
+  final TextStyle? descriptionStyle;
 
   /// Creates a new tutorial overlay.
   ///
@@ -163,8 +169,10 @@ class TutorialOverlay {
     this.skipButtonStyle,
     this.showButtons = true,
     this.nextText,
-    this.finshText,
+    this.finishText,
     this.skipText,
+    this.titleStyle,
+    this.descriptionStyle,
   }) : assert(
          dismissable || showButtons,
          'showButtons must be true or set dismissable to true\n'
@@ -240,6 +248,8 @@ Other possible causes:
     _overlayEntry = OverlayEntry(
       builder: (context) {
         final screen = MediaQuery.of(context).size;
+        final availableTooltipWidth =
+            (screen.width - edgePadding * 2).clamp(0.0, double.infinity);
 
         final safetyBottomMargin = 20;
 
@@ -256,20 +266,35 @@ Other possible causes:
             ? (holeRect.top - edgePadding - tooltipEstimatedHeight)
             : (holeRect.bottom + edgePadding);
 
-        tooltipTop = tooltipTop.clamp(
-          edgePadding,
-          screen.height - edgePadding - tooltipEstimatedHeight,
-        );
+        final minTooltipTop = edgePadding;
+        final maxTooltipTop =
+          (screen.height - edgePadding - tooltipEstimatedHeight).toDouble();
+        tooltipTop = maxTooltipTop >= minTooltipTop
+          ? tooltipTop.clamp(minTooltipTop, maxTooltipTop).toDouble()
+          : minTooltipTop;
 
         // Horizontal position: centered on hole
-        final double tooltipWidth = tooltipMaxWidth;
-        final double tooltipLeft = (holeRect.center.dx - tooltipWidth / 2)
-            .clamp(edgePadding, screen.width - edgePadding - tooltipWidth);
+        final tooltipWidth = tooltipMaxWidth.isFinite
+          ? tooltipMaxWidth.clamp(0.0, availableTooltipWidth).toDouble()
+          : availableTooltipWidth;
+        final preferredTooltipLeft = holeRect.center.dx - tooltipWidth / 2;
+        final minTooltipLeft = edgePadding;
+        final maxTooltipLeft =
+          (screen.width - edgePadding - tooltipWidth).toDouble();
+        final tooltipLeft = maxTooltipLeft >= minTooltipLeft
+          ? preferredTooltipLeft
+              .clamp(minTooltipLeft, maxTooltipLeft)
+              .toDouble()
+          : minTooltipLeft;
 
         // Arrow offset inside tooltip (relative to its width)
-        final arrowDx = (holeRect.center.dx - tooltipLeft)
-            .clamp(20, tooltipWidth - 20)
-            .toDouble();
+        final minArrowDx = 20.0;
+        final maxArrowDx = (tooltipWidth - 20).toDouble();
+        final arrowDx = maxArrowDx >= minArrowDx
+          ? (holeRect.center.dx - tooltipLeft)
+              .clamp(minArrowDx, maxArrowDx)
+              .toDouble()
+          : tooltipWidth / 2;
 
         return Stack(
           children: [
@@ -360,7 +385,7 @@ Other possible causes:
               children: [
                 Text(
                   title,
-                  style: TextStyle(
+                  style: titleStyle ??TextStyle(
                     fontSize: 18,
                     fontWeight: FontWeight.bold,
                     color: titleTextColor ?? Colors.black87,
@@ -369,7 +394,7 @@ Other possible causes:
                 const SizedBox(height: 12),
                 Text(
                   text,
-                  style: TextStyle(
+                  style: descriptionStyle ?? TextStyle(
                     fontSize: 16,
                     color: descriptionTextColor ?? Colors.black87,
                   ),
@@ -400,7 +425,7 @@ Other possible causes:
                             : (nextButtonStyle ?? _buildDefaultButtonStyle()),
                         child: Text(
                           isLastStep
-                              ? (finshText ?? 'Finsh')
+                              ? (finishText ?? 'Finish')
                               : (nextText ?? 'Next'),
                         ),
                       ),
@@ -472,7 +497,9 @@ Other possible causes:
             ),
             child: BackdropFilter(
               filter: ImageFilter.blur(sigmaX: blurSigma, sigmaY: blurSigma),
-              child: Container(color: Colors.black.withAlpha(blurOpacity)),
+              child: Container(
+                color: overlayTint.withAlpha(blurOpacity.clamp(0, 255).toInt()),
+              ),
             ),
           ),
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_tutorial_overlay
 
 description: "A Flutter package to create interactive tutorials, onboarding flows, guided tours, and user instruction overlays with step-by-step highlights and tooltips."
 
-version: 1.0.5
+version: 1.0.6
 homepage: https://github.com/AliA5y/flutter_tutorial_overlay
 repository: https://github.com/AliA5y/flutter_tutorial_overlay
 issue_tracker: https://github.com/AliA5y/flutter_tutorial_overlay/issues


### PR DESCRIPTION
# Summary
This PR adds custom text style support for the tutorial tooltip and fixes several layout and rendering bugs.

# Changes

## Added
- `titleStyle` (`TextStyle?`) parameter on `TutorialOverlay` - overrides the default title text style.
- `descriptionStyle` (`TextStyle?`) parameter on `TutorialOverlay` - overrides the default description text style.

## Fixed
- `tooltipMaxWidth` - previously ignored for full-screen-width tooltips; now correctly clamps to available screen width minus edge padding.
- `overlayTint` - was not being applied to the `BackdropFilter` container; now correctly uses `overlayTint.withAlpha(...)` instead of hardcoded `Colors.black`.
- Tooltip/arrow clamping - defensive `clamp` guards added to prevent assertion errors when `max < min` (e.g. on very small screens or extreme padding values).
- Typo - `finishText` parameter name and related assertions corrected.